### PR TITLE
Improves odohconfig parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "odoh-client-rs"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odoh-client-rs"
-version = "0.1.5"
+version = "0.1.6"
 authors = [ "Tanya Verma <tverma@cloudflare.com>" ]
 edition = "2018"
 license = "BSD-2-Clause"


### PR DESCRIPTION
Adds tests for `odohconfig` parsing, so when the `trust-dns-client` library adds support for [HTTPS](https://github.com/bluejekyll/trust-dns/issues/1323), we can reuse these tests. 

Also improves the parsing logic to only consider the first instance of `ODOH_VERSION` in the HTTPS string, hence avoiding splits if `ff03` (aka `ODOH_VERSION`) shows up again in the randomly generated public key.