### PR TITLE
Adds support for fetching odohconfig from well-known endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "odoh-client-rs"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odoh-client-rs"
-version = "0.1.7"
+version = "0.1.8"
 authors = [ "Tanya Verma <tverma@cloudflare.com>" ]
 edition = "2018"
 license = "BSD-2-Clause"

--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ The proxy and resolver are configured using the file specified by the `-c` flag,
 ```bash
 $ cargo run -- example.com AAAA
 ```
+
+Instead of using `HTTPS` DNS records to retrieve configs, it can be configured to use a well known endpoint to retrieve the configs via `GET` requests. This can be done by setting the `-w` flag:
+
+```bash
+$ cargo run -- example.com A -w
+```

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,5 +7,10 @@ mod tests {
         let mut cmd = Command::cargo_bin("odoh-client-rs").unwrap();
         let assert = cmd.args(&["google.com", "A"]).assert();
         assert.success();
+
+        cmd = Command::cargo_bin("odoh-client-rs").unwrap();
+
+        let assert_well_known = cmd.args(&["example.com", "AAAA", "-w"]).assert();
+        assert_well_known.success();
     }
 }


### PR DESCRIPTION
I'm not removing the option of using HTTPS records for fetching odohconfigs just yet, or making it the default, once it is removed or not recommended in the draft, I will update accordingly.